### PR TITLE
Fix client table refresh after adding new client

### DIFF
--- a/barber_saas/cadastros/mixins.py
+++ b/barber_saas/cadastros/mixins.py
@@ -7,7 +7,11 @@ from django.template.loader import render_to_string  # <- precisa deste import
 from django.http import HttpResponse
 
 def is_htmx(request):
-    return request.headers.get("HX-Request") == "true"
+    """Return True if the request comes from HTMX."""
+    return (
+        request.headers.get("HX-Request") == "true"
+        or request.META.get("HTTP_HX_REQUEST") == "true"
+    )
 
 class OwnerQuerysetMixin(LoginRequiredMixin):
     def get_queryset(self):

--- a/barber_saas/cadastros/views.py
+++ b/barber_saas/cadastros/views.py
@@ -489,13 +489,13 @@ class ClientCreateView(OwnerCreateMixin, OwnerQuerysetMixin, CreateView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx["title"] = "Novo cliente"
+        ctx["refresh_event"] = "refreshClientsTable"
         return ctx
 
     def form_valid(self, form):
         self.object = form.save()
         resp = HttpResponse("")
-        # fecha modal e pede refresh da tabela
-        resp["HX-Trigger"] = '{"closeModal": true, "refreshClientsTable": true, "toast": "Cliente salvo."}'
+        resp["HX-Trigger"] = '{"toast": "Cliente salvo."}'
         return resp
 
 
@@ -507,12 +507,13 @@ class ClientUpdateView(OwnerUpdateMixin, OwnerQuerysetMixin, UpdateView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         ctx["title"] = "Editar cliente"
+        ctx["refresh_event"] = "refreshClientsTable"
         return ctx
 
     def form_valid(self, form):
         self.object = form.save()
         resp = HttpResponse("")
-        resp["HX-Trigger"] = '{"closeModal": true, "refreshClientsTable": true, "toast": "Cliente atualizado."}'
+        resp["HX-Trigger"] = '{"toast": "Cliente atualizado."}'
         return resp
 
 


### PR DESCRIPTION
## Summary
- Ensure HTMX requests are detected reliably
- Dispatch refresh event for client list and show toast messages after saving

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a268ef304c833288a22be8695b4e7b