### PR TITLE
Allow service items with blank unit price

### DIFF
--- a/barber_saas/servicos/forms.py
+++ b/barber_saas/servicos/forms.py
@@ -2,7 +2,10 @@ from django import forms
 from django.forms import inlineformset_factory
 from cadastros.models import Shop, Product, Staff
 from .models import ServiceOrder, ServiceItem, Client
-from cadastros.forms import TenantOwnedForm  # sua base que injeta owner/current_user
+from cadastros.forms import (
+    TenantOwnedForm,
+    CommaDecimalField,
+)  # sua base que injeta owner/current_user
 from django.forms.models import BaseInlineFormSet  # <- importante
 
 class ServiceOrderForm(TenantOwnedForm):
@@ -32,6 +35,8 @@ class ServiceOrderForm(TenantOwnedForm):
         return obj
 
 class ServiceItemForm(TenantOwnedForm):
+    unit_price = CommaDecimalField(required=False, min_value=0)
+
     class Meta:
         model = ServiceItem
         fields = ["product", "qty", "unit_price"]

--- a/barber_saas/servicos/tests.py
+++ b/barber_saas/servicos/tests.py
@@ -1,3 +1,32 @@
+from decimal import Decimal
 from django.test import TestCase
+from django.contrib.auth import get_user_model
 
-# Create your tests here.
+from cadastros.models import Shop, Product
+from .models import ServiceOrder
+from .forms import ServiceItemForm
+
+
+class ServiceItemFormTests(TestCase):
+    def test_autofill_price_when_not_provided(self):
+        User = get_user_model()
+        owner = User.objects.create_user("owner@example.com", "pw12345")
+        shop = Shop.objects.create(owner=owner, name="Main Shop")
+        product = Product.objects.create(
+            owner=owner, name="Corte", default_price=Decimal("25.00")
+        )
+        order = ServiceOrder.objects.create(owner=owner, shop=shop)
+
+        form = ServiceItemForm(
+            data={"product": product.pk, "qty": 1, "unit_price": ""}, owner=owner
+        )
+        self.assertTrue(form.is_valid())
+
+        item = form.save(commit=False)
+        item.order = order
+        item.owner = owner
+        item.save()
+
+        self.assertEqual(item.unit_price, product.default_price)
+        order.refresh_from_db()
+        self.assertEqual(order.subtotal, product.default_price)


### PR DESCRIPTION
## Summary
- Allow service item unit price to be optional with CommaDecimalField
- Test that service items auto-fill price and update totals when no price is provided

## Testing
- `python manage.py test` *(fails: No module named 'django')*
- `pip install "django==4.2.*"` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a26f13d8dc83329612d5c2e828b56e