### PR TITLE
Use CommaDecimalField in service forms

### DIFF
--- a/barber_saas/servicos/forms.py
+++ b/barber_saas/servicos/forms.py
@@ -2,10 +2,15 @@ from django import forms
 from django.forms import inlineformset_factory
 from cadastros.models import Shop, Product, Staff
 from .models import ServiceOrder, ServiceItem, Client
-from cadastros.forms import TenantOwnedForm  # sua base que injeta owner/current_user
+from cadastros.forms import (
+    TenantOwnedForm,
+    CommaDecimalField,
+)  # sua base que injeta owner/current_user
 from django.forms.models import BaseInlineFormSet  # <- importante
 
 class ServiceOrderForm(TenantOwnedForm):
+    amount_paid = CommaDecimalField(required=False)
+    discount_amount = CommaDecimalField(required=False)
     class Meta:
         model = ServiceOrder
         fields = [
@@ -23,6 +28,11 @@ class ServiceOrderForm(TenantOwnedForm):
         if not self.instance.pk:
             self.fields["status"].initial = ServiceOrder.STATUS_IN_PROGRESS
 
+        for name in ("amount_paid", "discount_amount"):
+            val = self.initial.get(name)
+            if val not in (None, ""):
+                self.initial[name] = str(val).replace(".", ",")
+
     def save(self, commit=True):
         obj = super().save(commit=False)
         # sempre sincroniza nome/telefone do cliente selecionado
@@ -32,6 +42,8 @@ class ServiceOrderForm(TenantOwnedForm):
         return obj
 
 class ServiceItemForm(TenantOwnedForm):
+    unit_price = CommaDecimalField(required=False)
+
     class Meta:
         model = ServiceItem
         fields = ["product", "qty", "unit_price"]
@@ -59,6 +71,10 @@ class ServiceItemForm(TenantOwnedForm):
             qs = Product.objects.none()
 
         self.fields["product"].queryset = qs
+
+        val = self.initial.get("unit_price")
+        if val not in (None, ""):
+            self.initial["unit_price"] = str(val).replace(".", ",")
 
 class OwnerInlineFormSet(BaseInlineFormSet):
     def __init__(self, *args, owner=None, current_user=None, **kwargs):

--- a/barber_saas/servicos/tests.py
+++ b/barber_saas/servicos/tests.py
@@ -1,3 +1,73 @@
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-# Create your tests here.
+from cadastros.models import Shop, Staff, Client, Product
+from servicos.models import ServiceOrder, ServiceItem
+
+from .forms import ServiceOrderForm, ServiceItemForm
+
+
+class CommaDecimalFieldFormTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.owner = User.objects.create_user("owner@example.com", "pass")
+        self.staff_user = User.objects.create_user("staff@example.com", "pass")
+
+        self.shop = Shop.objects.create(owner=self.owner, name="Shop")
+        self.staff = Staff.objects.create(owner=self.owner, user=self.staff_user, full_name="Staff")
+        self.client = Client.objects.create(owner=self.owner, name="Client")
+        self.product = Product.objects.create(owner=self.owner, name="Prod", default_price=Decimal("0.00"))
+
+        self.order = ServiceOrder.objects.create(
+            owner=self.owner, shop=self.shop, staff=self.staff, client=self.client
+        )
+
+    def test_service_order_form_parses_comma_decimal(self):
+        data = {
+            "shop": self.shop.pk,
+            "client": self.client.pk,
+            "staff": self.staff.pk,
+            "scheduled_for": "",
+            "status": ServiceOrder.STATUS_IN_PROGRESS,
+            "discount_amount": "10,50",
+            "payment_method": "",
+            "amount_paid": "20,75",
+            "notes": "",
+        }
+        form = ServiceOrderForm(data=data, instance=ServiceOrder(owner=self.owner))
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["discount_amount"], Decimal("10.50"))
+        self.assertEqual(form.cleaned_data["amount_paid"], Decimal("20.75"))
+
+    def test_service_order_form_initial_uses_comma(self):
+        instance = ServiceOrder(
+            owner=self.owner,
+            shop=self.shop,
+            staff=self.staff,
+            client=self.client,
+            discount_amount=Decimal("5.50"),
+            amount_paid=Decimal("3.25"),
+        )
+        form = ServiceOrderForm(instance=instance)
+        self.assertEqual(form.initial["discount_amount"], "5,50")
+        self.assertEqual(form.initial["amount_paid"], "3,25")
+
+    def test_service_item_form_parses_comma_decimal(self):
+        data = {"product": self.product.pk, "qty": 1, "unit_price": "10,50"}
+        form = ServiceItemForm(data=data, owner=self.owner)
+        self.assertTrue(form.is_valid(), form.errors)
+        self.assertEqual(form.cleaned_data["unit_price"], Decimal("10.50"))
+
+    def test_service_item_form_initial_uses_comma(self):
+        item = ServiceItem(
+            owner=self.owner,
+            order=self.order,
+            product=self.product,
+            qty=1,
+            unit_price=Decimal("2.25"),
+        )
+        form = ServiceItemForm(instance=item, owner=self.owner)
+        self.assertEqual(form.initial["unit_price"], "2,25")
+


### PR DESCRIPTION
## Summary
- parse comma-based decimals for service items and orders
- normalize initial decimal values using commas
- add tests for comma decimal parsing

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a26f1349008332bb757de8ab435a4d