### PR TITLE
Fix owner handling and auto-fill item prices

### DIFF
--- a/barber_saas/servicos/forms.py
+++ b/barber_saas/servicos/forms.py
@@ -1,3 +1,5 @@
+import json
+
 from django import forms
 from django.forms import inlineformset_factory
 from cadastros.models import Shop, Product, Staff
@@ -72,6 +74,11 @@ class ServiceItemForm(TenantOwnedForm):
             qs = Product.objects.none()
 
         self.fields["product"].queryset = qs
+
+        # Map product IDs to their default prices so the frontend can
+        # automatically fill the unit price when a product is chosen.
+        prices = {str(p.pk): str(p.default_price) for p in qs}
+        self.fields["product"].widget.attrs["data-prices"] = json.dumps(prices)
 
         val = self.initial.get("unit_price")
         if val not in (None, ""):

--- a/barber_saas/servicos/templates/servicos/_order_modal.html
+++ b/barber_saas/servicos/templates/servicos/_order_modal.html
@@ -75,3 +75,19 @@
   </form>
 </div>
 
+<script>
+  // Preenche o campo de preço unitário ao selecionar um produto.
+  document.addEventListener('change', function (e) {
+    if (e.target.matches('select[name$="-product"]')) {
+      const select = e.target;
+      const prices = JSON.parse(select.dataset.prices || '{}');
+      const price = prices[select.value] || '';
+      const row = select.closest('tr');
+      const input = row ? row.querySelector('input[name$="-unit_price"]') : null;
+      if (input) {
+        input.value = price.toString().replace('.', ',');
+      }
+    }
+  });
+</script>
+

--- a/barber_saas/servicos/tests.py
+++ b/barber_saas/servicos/tests.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+import json
 
 from django.contrib.auth import get_user_model
 
@@ -71,5 +72,12 @@ class CommaDecimalFieldFormTests(TestCase):
         )
         form = ServiceItemForm(instance=item, owner=self.owner)
         self.assertEqual(form.initial["unit_price"], "2,25")
+
+    def test_service_item_form_exposes_price_mapping(self):
+        form = ServiceItemForm(owner=self.owner)
+        data_attr = form.fields["product"].widget.attrs.get("data-prices", "{}")
+        prices = json.loads(data_attr)
+        self.assertIn(str(self.product.pk), prices)
+        self.assertEqual(prices[str(self.product.pk)], str(self.product.default_price))
 
 


### PR DESCRIPTION
## Summary
- Ensure TenantOwnedForm preserves owner during initialization
- Auto-fill service item prices from product defaults
- Add tests for price mapping on service items

## Testing
- `python barber_saas/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a2721f6510833283b29a2fd7e529e6