### PR TITLE
Fix unit price assignment to use numeric value

### DIFF
--- a/barber_saas/servicos/templates/servicos/_order_modal.html
+++ b/barber_saas/servicos/templates/servicos/_order_modal.html
@@ -85,7 +85,7 @@
       const row = select.closest('tr');
       const input = row ? row.querySelector('input[name$="-unit_price"]') : null;
       if (input) {
-        input.value = price.toString().replace('.', ',');
+        input.value = price.toString();
       }
     }
   });


### PR DESCRIPTION
## Summary
- ensure unit price input uses numeric value without comma replacement

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a274a9208083328d8c26bf8fdbeedc