### PR TITLE
Ensure owner set on new service items

### DIFF
--- a/barber_saas/servicos/forms.py
+++ b/barber_saas/servicos/forms.py
@@ -95,6 +95,14 @@ class OwnerInlineFormSet(BaseInlineFormSet):
         kwargs.setdefault("current_user", self._current_user)
         return super()._construct_form(i, **kwargs)
 
+    def save_new(self, form, commit=True):
+        obj = super().save_new(form, commit=False)
+        if self._owner:
+            obj.owner = self._owner
+        if commit:
+            obj.save()
+        return obj
+
 ServiceItemFormSet = inlineformset_factory(
     ServiceOrder, ServiceItem,
     form=ServiceItemForm,


### PR DESCRIPTION
## Summary
- Assign owner to newly created service items in `OwnerInlineFormSet`
- Confirm service item formset receives current owner in service order views

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_68a274ada8748332a32c9409282c2464